### PR TITLE
Fix glib VIPS logs going to pyvips.vinterpolate

### DIFF
--- a/pyvips/enums.py
+++ b/pyvips/enums.py
@@ -285,3 +285,6 @@ class PCS(object):
 
     LAB = 'lab'
     XYZ = 'xyz'
+
+
+__all__ = ['BandFormat', 'Access', 'Interpretation']

--- a/pyvips/vinterpolate.py
+++ b/pyvips/vinterpolate.py
@@ -42,3 +42,6 @@ class Interpolate(pyvips.VipsObject):
             raise Error('no such interpolator {0}'.format(name))
 
         return Interpolate(vi)
+
+
+__all__ = ['Interpolate']

--- a/pyvips/vregion.py
+++ b/pyvips/vregion.py
@@ -72,3 +72,6 @@ class Region(pyvips.VipsObject):
 
         pointer = ffi.gc(pointer, glib_lib.g_free)
         return ffi.buffer(pointer, psize[0])
+
+
+__all__ = ['Region']


### PR DESCRIPTION
Log messages from the native VIPS library were being logged via the `pyvips.vinterpolate` logger instead of `pyvips`. This was due to `pyvips/__init__.py` importing `*` from `pyvips.vinterpolate`, which has a `logger` property, resulting in `pyvips.logger` being replaced with `pyvips.vinterpolate.logger`.

This fixes that by adding `__all__` to all the modules being glob imported into `pyvips/__init__.py`.

e.g:
```
$ python
Python 3.7.4 (default, Sep 24 2019, 14:47:02) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging; logging.basicConfig(level=logging.WARN)
>>> import pyvips
>>> img = pyvips.Image.new_from_array([0])
>>> img.jpegsave_buffer(overshoot_deringing=True)
WARNING:pyvips.vinterpolate:VIPS: ignoring overshoot_deringing
```

```
$ python -c 'import pyvips; print(pyvips.logger)'
<Logger pyvips.vinterpolate (WARNING)>
```

After:
```
$ python -c 'import pyvips; print(pyvips.logger)'
<Logger pyvips (WARNING)>
```
