### PR TITLE
Move Introspect class to the public API

### DIFF
--- a/pyvips/__init__.py
+++ b/pyvips/__init__.py
@@ -187,7 +187,7 @@ from .vimage import *
 from .vregion import *
 
 __all__ = [
-    'Error', 'Image', 'Region', 'Operation', 'GValue', 'Interpolate', 'GObject',
+    'Error', 'Image', 'Region', 'Introspect', 'Operation', 'GValue', 'Interpolate', 'GObject',
     'VipsObject', 'type_find', 'type_name', 'version', '__version__',
     'at_least_libvips', 'API_mode',
     'get_suffixes',

--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -531,7 +531,7 @@ def cache_set_trace(trace):
 
 
 __all__ = [
-    'Operation',
+    'Introspect', 'Operation',
     'cache_set_max', 'cache_set_max_mem', 'cache_set_max_files',
     'cache_set_trace'
 ]


### PR DESCRIPTION
This allows the libvips generators (`cplusplus/gen-operators.py` and `doc/gen-function-list.py`) to use the new Introspect class.