### PR TITLE
docs: Fix simple typo, reques -> requires

### DIFF
--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -7,7 +7,7 @@ import pyvips
 
 class TestProgress:
     def test_progress(self):
-        # py27 reques this pattern for non-local modification
+        # py27 requires this pattern for non-local modification
         notes = {}
 
         def preeval_cb(image, progress):


### PR DESCRIPTION
There is a small typo in tests/test_progress.py.

Should read `requires` rather than `reques`.

