### PR TITLE
Update docs for `SourceCustom`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 env:
   global:
     - VIPS_VERSION_MAJOR=8
-    - VIPS_VERSION_MINOR=8
+    - VIPS_VERSION_MINOR=9
     - VIPS_VERSION_MICRO=0
     - PATH=$HOME/vips/bin:$PATH
     - LD_LIBRARY_PATH=$HOME/vips/lib:$LD_LIBRARY_PATH

--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ Non-conda install
 -----------------
 
 First, you need the libvips shared library on your library search path, version
-8.2 or later. On Linux and macOS, you can just install via your package
-manager; on Windows you can download a pre-compiled binary from the libvips
-website.
+8.2 or later, though at least version 8.9 is required for all features to work. 
+On Linux and macOS, you can just install via your package manager; on Windows you
+can download a pre-compiled binary from the libvips website.
 
 https://libvips.github.io/libvips/install.html
 

--- a/pyvips/vsourcecustom.py
+++ b/pyvips/vsourcecustom.py
@@ -9,9 +9,11 @@ logger = logging.getLogger(__name__)
 
 
 class SourceCustom(pyvips.Source):
-    """An source you can connect action signals to to implement
-    behaviour.
+    """Custom sources allow reading data from otherwise unsupported sources.
+    Requires libvips `>= 8.9.0`.
 
+    To use, create a SourceCustom object, then provide callbacks to
+    :meth:`on_read` and :meth:`on_seek`.
     """
 
     def __init__(self):


### PR DESCRIPTION
Docs now mention libvips v8.9 is required for all features to work correctly. Closes https://github.com/libvips/pyvips/issues/218