### PR TITLE
Unref all assigned output objects prior raising an exception

### DIFF
--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -271,13 +271,13 @@ class Operation(pyvips.VipsObject):
 
         # set any optional args
         for name in kwargs:
-            value = kwargs[name]
-            details = intro.details[name]
-
             if (name not in intro.optional_input and
                     name not in intro.optional_output):
                 raise Error('{0} does not support optional argument {1}'
                             .format(operation_name, name))
+
+            value = kwargs[name]
+            details = intro.details[name]
 
             if (details['flags'] & _DEPRECATED) != 0:
                 logger.info('{0} argument {1} is deprecated',
@@ -289,6 +289,7 @@ class Operation(pyvips.VipsObject):
         # build operation
         vop = vips_lib.vips_cache_operation_build(op.pointer)
         if vop == ffi.NULL:
+            vips_lib.vips_object_unref_outputs(op.vobject)
             raise Error('unable to call {0}'.format(operation_name))
         op = Operation(vop)
 


### PR DESCRIPTION
This PR fixes a small memory leak when `vips_cache_operation_build` fails. This can can be reproduced with:
```bash
VIPS_LEAK=1 python3 -c "import pyvips; pyvips.Image.new_from_buffer(b'GIF89a', '')"
```
(requires libvips to be configured with giflib)

Other FFI-based bindings probably need something similar as well. I also reordered the unsupported optional argument check to avoid a `KeyError`. For example, I now see:
```bash
$ python3 -c "import pyvips; pyvips.Operation.call('black', 10, 10, banana=42)"
pyvips.error.Error: black does not support optional argument banana
```

Instead of:
```bash
$ python3 -c "import pyvips; pyvips.Operation.call('black', 10, 10, banana=42)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/local/lib64/python3.6/site-packages/pyvips/voperation.py", line 275, in call
    details = intro.details[name]
KeyError: 'banana'
```
