### PR TITLE
Fix logging deprecated arguments.

### DIFF
--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -280,8 +280,8 @@ class Operation(pyvips.VipsObject):
             details = intro.details[name]
 
             if (details['flags'] & _DEPRECATED) != 0:
-                logger.info('{0} argument {1} is deprecated',
-                            operation_name, name)
+                logger.info('{0} argument {1} is deprecated'
+                            .format(operation_name, name))
 
             _find_inside(add_reference, value)
             op.set(name, details['flags'], match_image, value)

--- a/pyvips/voperation.py
+++ b/pyvips/voperation.py
@@ -280,8 +280,8 @@ class Operation(pyvips.VipsObject):
             details = intro.details[name]
 
             if (details['flags'] & _DEPRECATED) != 0:
-                logger.info('{0} argument {1} is deprecated'
-                            .format(operation_name, name))
+                logger.info('%s argument %s is deprecated',
+                            operation_name, name)
 
             _find_inside(add_reference, value)
             op.set(name, details['flags'], match_image, value)


### PR DESCRIPTION
When a deprecated argument is used, an exception was being thrown because a format string was being used but the logger was expecting percent placeholders.  The current code would throw an exception.

For example:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/logging/__init__.py", line 994, in emit
    msg = self.format(record)
  File "/usr/lib/python3.6/logging/__init__.py", line 840, in format
    return fmt.format(record)
  File "/home/ubuntu/misc/girder_worker/env/lib/python3.6/site-packages/celery/utils/log.py", line 153, in format
    msg = logging.Formatter.format(self, record)
  File "/usr/lib/python3.6/logging/__init__.py", line 577, in format
    record.message = record.getMessage()
  File "/usr/lib/python3.6/logging/__init__.py", line 338, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
  ...
  File "/home/ubuntu/misc/girder_worker/env/lib/python3.6/site-packages/pyvips/vimage.py", line 547, in write_to_file
    string_options=options, **kwargs)
  File "/home/ubuntu/misc/girder_worker/env/lib/python3.6/site-packages/pyvips/voperation.py", line 284, in call
    operation_name, name)
Message: '{0} argument {1} is deprecated'
Arguments: ('VipsForeignSaveTiffFile', 'rgbjpeg')
```