### PR TITLE
Add flags helper

### DIFF
--- a/pyvips/base.py
+++ b/pyvips/base.py
@@ -129,6 +129,19 @@ def values_for_enum(gtype):
 
     return values
 
+def values_for_flag(gtype):
+    """Get all values for a flag (gtype)."""
+
+    g_type_class = gobject_lib.g_type_class_ref(gtype)
+    g_flags_class = ffi.cast('GFlagsClass *', g_type_class)
+
+    values = []
+
+    for i in range(0, g_flags_class.n_values):
+        value = _to_string(g_flags_class.values[i].value_nick)
+        values.append(value)
+
+    return values
 
 __all__ = [
     'leak_set',
@@ -142,5 +155,6 @@ __all__ = [
     'type_name',
     'type_map',
     'type_from_name',
-    'values_for_enum'
+    'values_for_enum',
+    'values_for_flag'
 ]

--- a/pyvips/vdecls.py
+++ b/pyvips/vdecls.py
@@ -177,13 +177,28 @@ def cdefs(features):
         } GEnumValue;
 
         typedef struct _GEnumClass {
-          GTypeClass *g_type_class;
+            GTypeClass *g_type_class;
 
-          int minimum;
-          int maximum;
-          unsigned int n_values;
-          GEnumValue *values;
+            int minimum;
+            int maximum;
+            unsigned int n_values;
+            GEnumValue *values;
         } GEnumClass;
+
+        typedef struct _GFlagsValue {
+            unsigned int value;
+
+            const char *value_name;
+            const char *value_nick;
+        } GFlagsValue;
+
+        typedef struct _GFlagsClass {
+            GTypeClass *g_type_class;
+
+            unsigned int mask;
+            unsigned int n_values;
+            GFlagsValue *values;
+        } GFlagsClass;
 
         void* g_type_class_ref (GType type);
 


### PR DESCRIPTION
Similar to #47, but for flags (e.g. `VipsForeignPngFilter`). Perhaps not very useful since that is the only flag/bitfield available in the public API of libvips (context: https://github.com/kleisauke/net-vips/pull/106).

I currently use this for wasm-vips here:
https://github.com/kleisauke/wasm-vips/blob/fafd4113090cf6b319d31d7db1f43f41f9b16f16/build/gen_type_declarations.py#L278
and:
https://github.com/kleisauke/wasm-vips/blob/fafd4113090cf6b319d31d7db1f43f41f9b16f16/build/gen_cpp_binding.py#L260