### PR TITLE
fix im.bandjoin([]) segfault

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@
 * add `to_array()` [jcupitt]
 * `repr()` will print matrix images as matrices [jcupitt]
 * more robust bandwise index/slice; added fancy slicing (step != 1) [erdmann]
+* fig segfault for `im.bandjoin([])`.  Now returns `im` [erdmann]
 
 ## Version 2.1.16 (28 Jun 2021)
 

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -1208,6 +1208,9 @@ class Image(pyvips.VipsObject):
         if not isinstance(other, list):
             other = [other]
 
+        if not other: # guard against empty list
+            return self
+
         # if [other] is all numbers, we can use bandjoin_const
         non_number = next((x for x in other
                            if not isinstance(x, numbers.Number)),

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -29,6 +29,9 @@ class TestImage:
         assert im.height == 16
         assert im.bands == 9
 
+        x = im.bandjoin([])
+        assert x.bands == 9
+
     def test_bandslice(self):
         black = pyvips.Image.black(16, 16)
         a = black.draw_rect(1, 0, 0, 1, 1)


### PR DESCRIPTION
In the process of developing the fancy slicing code, I encountered a segfault that I now see was caused by trying `im.bandjoin([])`.  This tiny PR fixes that by making `im.bandjoin([])` an identity operation, adds a test, and adds an entry to the CHANGELOG.  Fixes #311.