### PR TITLE
add numpy-style extended indexing, many new tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@
 * `repr()` will print matrix images as matrices [jcupitt]
 * more robust bandwise index/slice; added fancy slicing (step != 1) [erdmann]
 * fig segfault for `im.bandjoin([])`.  Now returns `im` [erdmann]
+* add numpy-style extended indexing (index with list of ints or bools) [erdmann]
 
 ## Version 2.1.16 (28 Jun 2021)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -103,11 +103,68 @@ class TestImage:
 
         assert x(0, 0) == seq[-10:10]
 
+        indices = [1, 2, 5]
+        x = im[indices]
+
+        assert x(0, 0) == [seq[i] for i in indices]
+
+        indices = [1, 2, -7]
+        x = im[indices]
+
+        assert x(0, 0) == [seq[i] for i in indices]
+
+        indices = [1]
+        x = im[indices]
+
+        assert x(0, 0) == [seq[1]]
+
+        indices = [-1]
+        x = im[indices]
+
+        assert x(0, 0) == [seq[-1]]
+
+        boolslice = [True, True, False, False, True, True, False]
+        x = im[boolslice]
+        assert x(0, 0) == [seq[i] for i,b in enumerate(boolslice) if b]
+
         with pytest.raises(IndexError):
             x = im[4:1]
 
         with pytest.raises(IndexError):
-            x = im[-8]
+            x = im[-(im.bands + 1)]
 
         with pytest.raises(IndexError):
-            x = im[7]
+            x = im[im.bands]
+
+        with pytest.raises(IndexError):
+            empty = [False] * im.bands
+            x = im[empty]
+
+        with pytest.raises(IndexError):
+            notenough = [True] * (im.bands - 1)
+            x = im[notenough]
+
+        with pytest.raises(IndexError):
+            toomany = [True] * (im.bands + 1)
+            x = im[toomany]
+
+        with pytest.raises(IndexError):
+            empty = []
+            x = im[empty]
+
+        with pytest.raises(IndexError):
+            oob = [2, 3, -8]
+            x = im[oob]
+
+        with pytest.raises(IndexError):
+            mixed = [True, 1, True, 2, True, 3, True]
+            x = im[mixed]
+
+        with pytest.raises(IndexError):
+            wrongtypelist = ['a', 'b', 'c']
+            x = im[wrongtypelist]
+
+        with pytest.raises(IndexError):
+            wrongargtype = dict(a=1, b=2)
+            x = im[wrongargtype]
+


### PR DESCRIPTION
Hi John,

In my work I often find myself switching back and forth between the numpy, pandas, pytorch, and JAX world and the pyvips world.  Those other libraries support numpy's extended indexing syntax, in which you can either use a list of ints to extract (possibly duplicate) targeted subsets of indices or a list of bools (so-called boolean indexing or boolean slicing) to indicate which indices to retain.  In a common use-case for me, when working with many-band reflectance imaging spectroscopy or MA-XRF images, it's frequently desirable to pull out specific bands by wavelength to make a false-color image or to select bands from several many-band images according to some single band-wise criterion.  Extended indexing with a list of ints and with a list of bools makes these two use cases much more convenient, for example.

Since I was on a roll with fixing the non-sequential slicing issue, I decided to also enhance `pyvips` so that it also understands this extended indexing syntax.

This PR does the following:
   - adds numpy-style list-of-ints and list-of-bools functionality to `__getindex__`
   - modifies the documentation accordingly
   - adds 14 new tests to ensure that all of the irritating edge cases I can think of are accounted for
   - fixes a bug in `__getindex__` that allowed args with the wrong type to slip through
   - adds a test for the above
   - modifies the CHANGELOG

I hope you find this to be a useful enhancement.