### PR TITLE
New functionality to go to and from numpy arrays.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,9 @@
 * fig segfault for `im.bandjoin([])`.  Now returns `im` [erdmann]
 * add numpy-style extended indexing (index with list of ints or bools) [erdmann]
 * earlier detection of unknown methods and class methods [jcupitt]
+* add conversion from Image to numpy array via 'Image.__array__` [erdmann]
+* add `Image.fromarray()` for conversion from numpy-ish arrays [erdmann]
+* add `Image.numpy()` (convenient for method chaining) [erdmann]
 
 ## Version 2.1.16 (28 Jun 2021)
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -168,3 +168,169 @@ class TestImage:
             wrongargtype = dict(a=1, b=2)
             x = im[wrongargtype]
 
+    def test_to_numpy(self):
+        try:
+            import numpy as np
+        except ImportError:
+            pytest.skip('numpy not available')
+
+        xy = pyvips.Image.xyz(4, 5)
+
+        # using __array__ interface:
+
+        from pyvips.vimage import TYPESTR_TO_FORMAT
+        for typestr, format in TYPESTR_TO_FORMAT.items():
+            this_xy = xy.cast(format)
+            yx = np.array(this_xy)
+            assert yx.dtype == np.dtype(typestr)
+            assert yx.shape == (5, 4, 2)
+            assert all(yx.max(axis=(0, 1)) == np.array([3, 4]))
+
+        x, y = xy
+        x_iy = pyvips.Image.complexform(x, y)
+        x_iy_dp = x_iy.cast('dpcomplex')
+
+        a = np.array(x_iy)
+        assert a.shape == (5, 4)
+        assert a.dtype == np.dtype('complex64')
+        assert a[4, 3].item() == 3+4j
+
+        a = np.array(x_iy_dp)
+        assert a.shape == (5, 4)
+        assert a.dtype == np.dtype('complex128')
+        assert a[4, 3].item() == 3+4j
+
+        xyxyxy = xy.bandjoin([xy, xy])
+        a = np.array(xyxyxy)
+        assert a.shape == (5, 4, 6)
+
+        # axes collapsing:
+        xyxyxy_col = xyxyxy.crop(3, 0, 1, 5)
+        assert xyxyxy_col.width == 1
+        assert xyxyxy_col.height == 5
+        a = np.array(xyxyxy_col)
+        assert a.shape == (5, 1, 6)
+
+        xyxyxy_row = xyxyxy.crop(0, 4, 4, 1)
+        assert xyxyxy_row.width == 4
+        assert xyxyxy_row.height == 1
+        a = np.array(xyxyxy_row)
+        assert a.shape == (1, 4, 6)
+
+        xyxyxy_px = xyxyxy.crop(3, 4, 1, 1)
+        assert xyxyxy_px.width == 1
+        assert xyxyxy_px.height == 1
+        a = np.array(xyxyxy_px)
+        assert a.shape == (1, 1, 6)
+
+        a = np.array(xyxyxy_px[0])
+        assert a.ndim == 0
+
+        # automatic conversion to array on ufunc application:
+
+        d = np.diff(xy.cast('short'), axis=1)
+        assert (d[..., 0] == 1).all()
+        assert (d[..., 1] == 0).all()
+
+        # tests of .numpy() method:
+
+        a = pyvips.Image.xyz(256,1)[0].numpy().squeeze()
+
+        assert all(a == np.arange(256))
+
+    def test_scipy(self):
+        try:
+            import numpy as np
+        except:
+            pytest.skip('numpy not available')
+
+        try:
+            from scipy import ndimage
+        except ImportError:
+            pytest.skip('scipy not available')
+
+        black = pyvips.Image.black(16, 16)
+        a = black.draw_rect(1, 0, 0, 1, 1)
+
+        d = ndimage.distance_transform_edt(a==0)
+        assert np.allclose(d[-1,-1], (2*15**2)**0.5)
+
+    def test_torch(self):
+        try:
+            import numpy as np
+        except:
+            pytest.skip('numpy not available')
+
+        try:
+            import torch
+        except ImportError:
+            pytest.skip('torch not available')
+
+        # torch to Image:
+        x = torch.outer(torch.arange(10), torch.arange(5))
+        with pytest.raises(ValueError): # no vips format for int64
+            im = pyvips.Image.fromarray(x)
+
+        x = x.float()
+
+        im = pyvips.Image.fromarray(x)
+        assert im.width == 5
+        assert im.height == 10
+        assert im(4, 9) == [36]
+        assert im.format == 'float'
+        
+        # Image to torch:
+        im = pyvips.Image.zone(5, 5)
+        t = torch.asarray(np.asarray(im))
+        assert t[2, 2] == 1.     
+        
+    def test_from_numpy(self):
+        try:
+            import numpy as np
+        except ImportError:
+            pytest.skip('numpy not available')
+
+        a = np.indices((5, 4)).transpose(1, 2, 0)  # (5, 4, 2)
+
+        with pytest.raises(ValueError):
+            yx = pyvips.Image.fromarray(a)  # no way in for int64
+
+        from pyvips.vimage import TYPESTR_TO_FORMAT
+
+        for typestr, format in TYPESTR_TO_FORMAT.items():
+            a = np.indices((5, 4), dtype=typestr).transpose(1, 2, 0)
+            yx = pyvips.Image.fromarray(a)
+            assert yx.format == format
+
+        a = np.zeros((2,2,2,2))
+
+        with pytest.raises(ValueError):
+            im = pyvips.Image.fromarray(a) # too many dimensions
+
+        a = np.ones((2,2,2), dtype=bool)
+        with pytest.raises(ValueError):
+            im = pyvips.Image.fromarray(a) # bool not supported due to ambiguity (255 or 1?)
+
+        a = np.ones((2,2,2), dtype='S8')
+        with pytest.raises(ValueError):
+            im = pyvips.Image.fromarray(a) # no way in for strings
+
+        l = [[1., 2.],[3., 4.]]
+        with pytest.raises(ValueError):
+            im = pyvips.Image.fromarray(a) # no way in for lists
+
+    def test_from_PIL(self):
+        try:
+            import PIL.Image
+        except ImportError:
+            pytest.skip('PIL not available')
+
+        pim = PIL.Image.new('RGB', (42, 23))
+
+        im = pyvips.Image.fromarray(pim)
+        assert im.format == 'uchar'
+        assert im.interpretation == 'rgb'
+        assert im.width == pim.width
+        assert im.height == pim.height
+        assert im.min() == 0
+        assert im.max() == 0


### PR DESCRIPTION
Ok, here's my stab at robust and flexible numpy interoperability.

This PR contains the following:
- a definition of `Image.fromarray` that uses `__array_interface__` or, if that's missing, `__array__`  to ingest numpy-like objects into pyvips.    This includes some heuristics that try to set the `interpretation` to something sensible when the user passes `'auto'` as the `interpretation` argument (the default; it can be easily set to any libvips interpretation by the user as desired.)  This means that we can also ingest lots of foreign array-like objects (PIL images, e.g.).
- a definition of `Image.__array__` to enable `pyvips.Image` objects to be consumed by numpy.  This enables explicit conversion like `np.asarray(image)` or `np.array(image)`, but also implicit conversion by numpy functions, such as `np.diff(image, axis=1)`.  This also means that images can be `plt.imshow`ed and that kind of stuff since functions in other scientific libraries often accept anything that can act like a numpy array.
- I use pytorch a lot, and I've grown quite fond of the ability to do stuff like `arr = mytensor.op1().op2().numpy()`, where the method chain ends with an explicit conversion to a numpy array.    I have been using this for a couple years on my private `pyvips.Image` subclass and found it to be really handy and compact, so I added `Image.numpy()` too as a convenience function.
- A boatload of new tests for conversion to and from numpy (only if it's installed) as well as conversions to/from pytorch and from PIL (also only if they're installed).  The tests illustrate and exercise all of the new capabilities.

Some points to note:
- There is no way to convert from an 'int64' or 'uint64' numpy array because as far as I know that's not a libvips format.  I think I asked this as a question on an issue a long time ago, but please correct me if I'm wrong.
- I'm currently not defining conversions from numpy arrays of bools, because this has led to some bugs in my past use.  Specifically, the issue is that libvips treats boolean operation results as uchar, and further  treats False as 0 and True as 255.   But Python treats True as 1 instead.  This can cause confusion, so here I'm following the "explicit is better than implicit" philosophy by forcing the user to manually convert numpy bool arrays to 'uint8' prior to giving them to pyvips.  I'm torn, though, because I could also see that less suffering would be caused by hard-coding that numpy bool to pyvips turns True to uchar(255).   It's already the case that pyvips uchar images get converted to numpy bool arrays with no surprises when the user manually specifies the `dtype` on `Image.__array__`.
- Single-band images map to 2D numpy arrays shape (H, W) rather than (H, W, 1) to save endless hours of irritation.  I retain single-row or single-column axes so that we get (1,W,C) or (1,W) for multi- or single-band one-row images, respectively, or (H,1,C) or(H,1) for multi- or single-band one-column images, respectively.  The only exception is a single-row, single-column, single-band image, which gets converted to a 0-dimensional numpy array.  All the above ensures that round trips from pyvips to numpy and back will preserve width, height, and bands.
- This doesn't make any attempt to implement the so-called [buffer protocol](https://docs.python.org/3/c-api/buffer.html), so we can't directly offer up our own `__array_interface__` yet.   A consequence is that PIL can't directly ingest pyvips Images without the user explicitly converting the image to a to numpy array first.
- Related to this, it would be pretty sweet to somehow manage to share memory between a numpy array and a pyvips Image, like how pytorch can make a zero-copy tensor from a numpy array.  Being able to `Image.copy_memory()` and then diddle with the memory directly from numpy or to have a numpy array that gets zero-copy viewed by pyvips as an Image for saving or other operations would be super powerful.   Is there a chance that such things would be feasible in the future?  (I realize there is complexity associated with avoiding double-freeing memory, etc., but note that `__array_interface__` allows offering memory as read-only if needed.)

Sorry for the wall of text; adding this bit of functionality was more subtle than I expected.