### PR TITLE
accept pathlib.Path as filename (with tests)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@
   numpy-ish arrays [erdmann]
 * add `Image.numpy()` (convenient for method chaining) [erdmann]
 * rename `toarray()` to `tolist()`, rewrite for efficiency [erdmann]
+* accept `pathlib.Path` objects for filenames (py3 only) [erdmann]
 
 ## Version 2.1.16 (28 Jun 2021)
 

--- a/pyvips/error.py
+++ b/pyvips/error.py
@@ -10,7 +10,9 @@ logger = logging.getLogger(__name__)
 _is_PY3 = sys.version_info[0] == 3
 
 if _is_PY3:
-    text_type = str
+    # pathlib is not part of Python 2 stdlib
+    from pathlib import Path
+    text_type = str, Path
     byte_type = bytes
 else:
     text_type = unicode
@@ -20,12 +22,13 @@ else:
 def _to_bytes(x):
     """Convert to a byte string.
 
-    Convert a Python unicode string to a utf-8-encoded byte string. You must
-    call this on strings you pass to libvips.
+    Convert a Python unicode string or a pathlib.Path to a utf-8-encoded
+    byte string. You must call this on strings you pass to libvips.
 
     """
     if isinstance(x, text_type):
-        x = x.encode('utf-8')
+        # n.b. str also converts pathlib.Path objects
+        x = str(x).encode('utf-8')
 
     return x
 

--- a/tests/helpers/helpers.py
+++ b/tests/helpers/helpers.py
@@ -1,6 +1,7 @@
 # vim: set fileencoding=utf-8 :
 # test helpers
 import os
+import sys
 import tempfile
 import pytest
 
@@ -9,6 +10,8 @@ import pyvips
 IMAGES = os.path.join(os.path.dirname(__file__), os.pardir, 'images')
 JPEG_FILE = os.path.join(IMAGES, "sample.jpg")
 WEBP_FILE = os.path.join(IMAGES, "sample.webp")
+
+_is_PY3 = sys.version_info[0] == 3
 
 
 # an expanding zip ... if either of the args is a scalar or a one-element list,

--- a/tests/test_saveload.py
+++ b/tests/test_saveload.py
@@ -3,8 +3,9 @@
 import os
 import tempfile
 
+import pytest
 import pyvips
-from helpers import temp_filename, skip_if_no
+from helpers import temp_filename, skip_if_no, _is_PY3, IMAGES, JPEG_FILE
 
 
 class TestSaveLoad:
@@ -35,6 +36,37 @@ class TestSaveLoad:
         assert x.bands == 1
 
         os.remove(x.filename)
+
+    @skip_if_no('jpegload')
+    def test_save_file_pathlib(self):
+        if not _is_PY3:
+            pytest.skip('pathlib not in stdlib in Python 2')
+
+        from pathlib import Path
+
+        filename = Path(temp_filename(self.tempdir, '.jpg'))
+
+        im = pyvips.Image.black(10, 20)
+        im.write_to_file(filename)
+        assert filename.exists()
+        filename.unlink()
+
+    @skip_if_no('jpegload')
+    def test_load_file_pathlib(self):
+        if not _is_PY3:
+            pytest.skip('pathlib not in stdlib in Python 2')
+
+        from pathlib import Path
+
+        filename = Path(IMAGES) / 'sample.jpg'
+        assert filename.exists()
+
+        im_a = pyvips.Image.new_from_file(JPEG_FILE)
+        im_b = pyvips.Image.new_from_file(filename)
+
+        assert im_a.bands == im_b.bands
+        assert im_a.width == im_b.width
+        assert im_a.height == im_b.height
 
     @skip_if_no('jpegload')
     def test_save_buffer(self):


### PR DESCRIPTION
As discussed in #313, this PR enables `pathlib.Path` objects as filenames in Python 3.   There was already an `isinstance` call in the `_to_bytes` function, so this shouldn't really affect performance.  I also added a couple of simple tests.