### PR TITLE
Fixed new_from_array, fixed test for older pytorch

### DIFF
--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -509,7 +509,9 @@ class Image(pyvips.VipsObject):
             shape = a['shape']
             typestr = a['typestr']
             ndim = len(shape)
-            strides = a['strides']
+
+            # strides is optional
+            strides = a.get('strides', None)
 
             if ndim > 3:
                 raise ValueError('array has more than 3 dimensions')

--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -535,12 +535,16 @@ class Image(pyvips.VipsObject):
 
             format = TYPESTR_TO_FORMAT[typestr]
 
-            if strides is None:
+            if strides is None and hasattr(obj, 'data'):
                 data = obj.data
             else:
                 # To obtain something with a contiguous memory layout
-                data = obj.tobytes() if hasattr(obj, 'tobytes') else \
-                    obj.tostring()
+                if hasattr(obj, 'tobytes'):
+                    data = obj.tobytes()
+                elif hasattr(obj, 'tostring'):
+                    data = obj.tostring()
+                else:
+                    raise TypeError('object has no .tobytes or .tostring')
 
             im = cls.new_from_memory(
                 data,
@@ -566,8 +570,8 @@ class Image(pyvips.VipsObject):
             # make it into something that *does* define __array_interface__
             return cls.new_from_array(obj.__array__())
         else:
-            raise ValueError('does not define __array_interface__ ' +
-                             'or __array__')
+            raise TypeError('does not define __array_interface__ '
+                            'or __array__')
 
     @staticmethod
     def new_from_memory(data, width, height, bands, format):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -342,6 +342,24 @@ class TestImage:
             # no way in for strings
             im = pyvips.Image.new_from_array(a)
 
+        # test handling of strided data
+        a = np.ones((1000, 1000, 3), dtype='uint8')[::10, ::10]
+        im = pyvips.Image.new_from_array(a)
+        assert im.width == 100
+        assert im.height == 100
+        assert im.bands == 3
+
+        class FakeArray(object):
+            @property
+            def __array_interface__(self):
+                return {'shape': (1, 1, 1),
+                        'typestr': '|u1',
+                        'version': 3}
+
+        with pytest.raises(TypeError):
+            # Handle evil objects that don't behave like ndarrays
+            im = pyvips.Image.new_from_array(FakeArray())
+
     def test_tolist(self):
         im = pyvips.Image.complexform(*pyvips.Image.xyz(3, 4))
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -303,7 +303,7 @@ class TestImage:
 
         # Image to torch:
         im = pyvips.Image.zone(5, 5)
-        t = torch.asarray(np.asarray(im))
+        t = torch.from_numpy(np.asarray(im))
         assert t[2, 2] == 1.
 
     def test_from_numpy(self):


### PR DESCRIPTION
Thanks for alerting me to the test failures with the new array functionalities.  This exposed a bug in `new_from_array`: 'stride' is actually optional under the [official specification ](https://numpy.org/doc/stable/reference/arrays.interface.html).   I was also needlessly relying on pytorch's `.asarray`, when `.from_numpy` would've sufficed.

Would you mind testing these with your alternate configurations to see that the test failures you noted are fixed?