### PR TITLE
Update for numpy/PIL: intro docs and example

### DIFF
--- a/examples/pil-numpy-pyvips.py
+++ b/examples/pil-numpy-pyvips.py
@@ -11,50 +11,6 @@ if len(sys.argv) != 3:
     print('usage: {0} input-filename output-filename'.format(sys.argv[0]))
     sys.exit(-1)
 
-# map vips formats to np dtypes
-format_to_dtype = {
-    'uchar': np.uint8,
-    'char': np.int8,
-    'ushort': np.uint16,
-    'short': np.int16,
-    'uint': np.uint32,
-    'int': np.int32,
-    'float': np.float32,
-    'double': np.float64,
-    'complex': np.complex64,
-    'dpcomplex': np.complex128,
-}
-
-# map np dtypes to vips
-dtype_to_format = {
-    'uint8': 'uchar',
-    'int8': 'char',
-    'uint16': 'ushort',
-    'int16': 'short',
-    'uint32': 'uint',
-    'int32': 'int',
-    'float32': 'float',
-    'float64': 'double',
-    'complex64': 'complex',
-    'complex128': 'dpcomplex',
-}
-
-
-# numpy array to vips image
-def numpy2vips(a):
-    height, width, bands = a.shape
-    linear = a.reshape(width * height * bands)
-    vi = pyvips.Image.new_from_memory(linear.data, width, height, bands,
-                                      dtype_to_format[str(a.dtype)])
-    return vi
-
-
-# vips image to numpy array
-def vips2numpy(vi):
-    return np.ndarray(buffer=vi.write_to_memory(),
-                      dtype=format_to_dtype[vi.format],
-                      shape=[vi.height, vi.width, vi.bands])
-
 
 # load with PIL
 start_pillow = time.time()
@@ -65,13 +21,13 @@ print('pil shape', pillow_img.shape)
 # load with vips to a memory array
 start_vips = time.time()
 img = pyvips.Image.new_from_file(sys.argv[1])
-np_3d = vips2numpy(img)
+np_3d = np.asarray(img) # or img.numpy()
 
 print('Vips Time:', time.time() - start_vips)
 print('vips shape', np_3d.shape)
 
-# make a vips image from the numpy array
-vi = numpy2vips(pillow_img)
+# make a vips image from the PIL image
+vi = pyvips.Image.new_from_array(pillow_img)
 
 # verify we have the same result
 # this can be non-zero for formats like jpg if the two libraries are using


### PR DESCRIPTION
Here's an update to intro.rst and to the  numpy/PIL example to reflect the new interconversion functionality.

Aside: Interestingly, when I run the updated example, which has some timing code left over from before, I see that PIL is quite a bit faster than pyvips for loading the images I tried:
```shell
examples$ python pil-numpy-pyvips.py ../tests/images/sample.jpg deleteme.jpg
Pillow Time: 0.018997669219970703
pil shape (768, 1024, 3)
Vips Time: 0.025973081588745117
vips shape (768, 1024, 3)
Average pil/vips difference: 0.0


examples$ python pil-numpy-pyvips.py /fast/demo.tif deleteme.tif
Pillow Time: 0.30741429328918457
pil shape (7384, 3192, 3)
Vips Time: 1.0770337581634521
vips shape (7384, 3192, 3)
Average pil/vips difference: 0.0
```

Is this what you expect?