### PR TITLE
Remove deprecated symbols

### DIFF
--- a/pyvips/base.py
+++ b/pyvips/base.py
@@ -70,15 +70,6 @@ def at_least_libvips(x, y):
 
     return major > x or (major == x and minor >= y)
 
-
-def path_filename7(filename):
-    return _to_string(vips_lib.vips_path_filename7(_to_bytes(filename)))
-
-
-def path_mode7(filename):
-    return _to_string(vips_lib.vips_path_mode7(_to_bytes(filename)))
-
-
 def type_find(basename, nickname):
     """Get the GType for a name.
 
@@ -139,8 +130,6 @@ __all__ = [
     'leak_set',
     'version',
     'at_least_libvips',
-    'path_filename7',
-    'path_mode7',
     'type_find',
     'nickname_find',
     'get_suffixes',

--- a/pyvips/vdecls.py
+++ b/pyvips/vdecls.py
@@ -67,9 +67,6 @@ def cdefs(features):
 
         void vips_leak_set (int leak);
 
-        char* vips_path_filename7 (const char* path);
-        char* vips_path_mode7 (const char* path);
-
         GType vips_type_find (const char* basename, const char* nickname);
         const char* vips_nickname_find (GType type);
 


### PR DESCRIPTION
Removing these functions ensures that libvips does not fall-back to ABI mode at runtime when building with the deprecated components disabled (`-Ddeprecated=false`), see:
https://github.com/libvips/libvips/issues/2947

These functions were only used by libvips' test suite, which are marked as `@pytest.mark.xfail`, so it's safe to remove.
