### PR TITLE
Find homebrew folder

### DIFF
--- a/pyvips/__init__.py
+++ b/pyvips/__init__.py
@@ -56,7 +56,15 @@ except Exception as e:
     if _is_windows:
         vips_lib = ffi.dlopen('libvips-42.dll')
     elif _is_mac:
-        vips_lib = ffi.dlopen('libvips.42.dylib')
+        vips_filename = 'libvips.42.dylib'
+        try:
+            vips_lib = ffi.dlopen(vips_filename)
+        except OSError:
+            _homebrew_lib_prefix = os.getenv('HOMEBREW_PREFIX')
+            if not _homebrew_lib_prefix:
+                raise
+            vips_path = os.path.join(_homebrew_lib_prefix, 'lib', vips_filename)
+            vips_lib = ffi.dlopen(vips_path)
     else:
         vips_lib = ffi.dlopen('libvips.so.42')
 


### PR DESCRIPTION
Hello,

Failing to use on macos with error:
```
OSError: cannot load library 'libvips.42.dylib': dlopen(libvips.42.dylib, 0x0002): tried: 'libvips.42.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibvips.42.dylib' (no such file), '/usr/lib/libvips.42.dylib' (no such file, not in dyld cache), 'libvips.42.dylib' (no such file), '/usr/lib/libvips.42.dylib' (no such file, not in dyld cache).  Additionally, ctypes.util.find_library() did not manage to locate a library called 'libvips.42.dylib'
```

Not sure why, but for mac M* the homebrew folder is different by default. My homebrew folder is `/opt/homebrew`, tried with the following change and worked fine. Let me know what you think.

Thanks!