### PR TITLE
Avoid declaring types and functions in API mode

### DIFF
--- a/pyvips/pyvips_build.py
+++ b/pyvips/pyvips_build.py
@@ -49,22 +49,6 @@ ffibuilder.set_source("_libvips",
     """ + compat,
     **pkgconfig.parse('vips'))
 
-features = {
-    'major': major,
-    'minor': minor,
-    'micro': micro,
-    'api': True,
-}
-
-
-import vdecls
-
-# handy for debugging
-# with open('vips-source.txt','w') as f:
-#     c = vdecls.cdefs(features)
-#     f.write(c)
-
-ffibuilder.cdef(vdecls.cdefs(features))
 
 if __name__ == "__main__":
     ffibuilder.compile(verbose=True)

--- a/pyvips/vdecls.py
+++ b/pyvips/vdecls.py
@@ -153,14 +153,6 @@ def cdefs(features):
             unsigned int flags;
             GType value_type;
             GType owner_type;
-
-            // private, but cffi in API mode needs these to be able to get the
-            // offset of any member
-            char* _nick;
-            char* _blurb;
-            GData* qdata;
-            unsigned int ref_count;
-            unsigned int param_id;
         } GParamSpec;
 
         typedef struct _GEnumValue {


### PR DESCRIPTION
This appears redundant, as these types and functions originate from `vips/vips.h` in API mode.

Resolves: #459.