### PR TITLE
Fix `type_map()`

### DIFF
--- a/pyvips/vdecls.py
+++ b/pyvips/vdecls.py
@@ -72,8 +72,8 @@ def cdefs(features):
         const char* g_type_name (GType gtype);
         GType g_type_from_name (const char* name);
 
-        typedef ... VipsTypeMap2Fn;
-        void* vips_type_map (GType base, VipsTypeMap2Fn fn, void* a, void* b);
+        typedef void* (*VipsTypeMap2Fn) (GType type, void* a, void* b);
+        void* vips_type_map (GType base, void* fn, void* a, void* b);
 
         const char* vips_error_buffer (void);
         void vips_error_clear (void);


### PR DESCRIPTION
We cannot declare `VipsTypeMap2Fn` as opaque as this callback is used by `type_map()`. Instead, restore the `VipsTypeMap2Fn` definition and use an opaque pointer for the second argument of `vips_type_map()`.

<details>
  <summary>Details</summary>

```console
$ python3 gen_cpp_binding.py
Traceback (most recent call last):
  File "/home/kleisauke/wasm-vips/build/gen_cpp_binding.py", line 295, in <module>
    generate_enums_flags('enums.cpp')
  File "/home/kleisauke/wasm-vips/build/gen_cpp_binding.py", line 230, in generate_enums_flags
    type_map(type_from_name('GEnum'), add_enum)
  File "/home/kleisauke/.local/lib/python3.12/site-packages/pyvips/base.py", line 105, in type_map
    cb = ffi.callback('VipsTypeMap2Fn', fn)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected a function ctype, got 'VipsTypeMap2Fn'
```
</details>

Regressed since: #464.