### PR TITLE
Fix a small memleak in `write_to_buffer()`

### DIFF
--- a/pyvips/vimage.py
+++ b/pyvips/vimage.py
@@ -849,6 +849,7 @@ class Image(pyvips.VipsObject):
         format_string = _to_bytes(format_string)
 
         filename = vips_lib.vips_filename_get_filename(format_string)
+        filename = ffi.gc(filename, glib_lib.g_free)
 
         pointer = vips_lib.vips_filename_get_options(format_string)
         options = _to_string_copy(pointer)


### PR DESCRIPTION
<details>
  <summary>Details</summary>

```
Direct leak of 50 byte(s) in 10 object(s) allocated from:
    #0 0x7f56304f87a3 in malloc (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0xf87a3) (BuildId: bf9e3747052c46cd49f7974555b1700dce30b8c0)
    #1 0x7f562a4b6af9 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62af9) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #2 0x7f562a4cc4c8 in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x784c8) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #3 0x7f562b3a9911 in g_strdup_inline /usr/include/glib-2.0/glib/gstrfuncs.h:321:10
    #4 0x7f562b3a9911 in vips_filename_get_filename /home/runner/work/libvips/libvips/build/../libvips/iofuncs/image.c:1824:9
    #5 0x7f562e5526ce in _cffi_f_vips_filename_get_filename /tmp/pip-install-tnijg7ko/pyvips_6f6cb95fa33a4d4aba0ddc05ba43b931/build/temp.linux-x86_64-cpython-312/_libvips.c:3308:14
    #6 0x5d7b6a in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d7b6a) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #7 0x54c8c1  (/usr/bin/python3.12+0x54c8c1) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #8 0x5db335 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5db335) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #9 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #10 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #11 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #12 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #13 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #14 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #15 0x54aecb in PyObject_Call (/usr/bin/python3.12+0x54aecb) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #16 0x5db335 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5db335) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #17 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #18 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #19 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #20 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #21 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #22 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #23 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #24 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #25 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #26 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #27 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #28 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)

Direct leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7f56304f87a3 in malloc (/usr/lib/llvm-18/lib/clang/18/lib/linux/libclang_rt.asan-x86_64.so+0xf87a3) (BuildId: bf9e3747052c46cd49f7974555b1700dce30b8c0)
    #1 0x7f562a4b6af9 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62af9) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #2 0x7f562a4cc4c8 in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x784c8) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #3 0x7f562b3a9911 in g_strdup_inline /usr/include/glib-2.0/glib/gstrfuncs.h:321:10
    #4 0x7f562b3a9911 in vips_filename_get_filename /home/runner/work/libvips/libvips/build/../libvips/iofuncs/image.c:1824:9
    #5 0x7f562e5526ce in _cffi_f_vips_filename_get_filename /tmp/pip-install-tnijg7ko/pyvips_6f6cb95fa33a4d4aba0ddc05ba43b931/build/temp.linux-x86_64-cpython-312/_libvips.c:3308:14
    #6 0x581ee1  (/usr/bin/python3.12+0x581ee1) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #7 0x549714 in PyObject_Vectorcall (/usr/bin/python3.12+0x549714) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #8 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #9 0x54c8c1  (/usr/bin/python3.12+0x54c8c1) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #10 0x5db335 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5db335) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #11 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #12 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #13 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #14 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #15 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #16 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #17 0x54aecb in PyObject_Call (/usr/bin/python3.12+0x54aecb) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #18 0x5db335 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5db335) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #19 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #20 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #21 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #22 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #23 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #24 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #25 0x548ddd in _PyObject_MakeTpCall (/usr/bin/python3.12+0x548ddd) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #26 0x5d70f8 in _PyEval_EvalFrameDefault (/usr/bin/python3.12+0x5d70f8) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #27 0x54a629 in _PyObject_Call_Prepend (/usr/bin/python3.12+0x54a629) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
    #28 0x5a3217  (/usr/bin/python3.12+0x5a3217) (BuildId: ccd329aaf9256b96135a9e3f97cbf4c3829377e1)
```

https://github.com/kleisauke/libvips/actions/runs/10557963869/job/29246536686#step:14:2499
</details>