### PR TITLE
Revise logic for unified (semistatic) libvips binaries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,9 @@
-# master 
+# master
+
+- fix a small memleak in `write_to_buffer()` [kleisauke]
+- revise logic for unified (semistatic) libvips binaries [kleisauke]
+
+## Version 2.2.3 (released 28 April 2024)
 
 - ensure compatibility with a single shared libvips library [kleisauke]
 - add flags_dict(), enum_dict() for better flags introspection

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,4 @@
-# master
-
-- fix a small memleak in `write_to_buffer()` [kleisauke]
-- revise logic for unified (semistatic) libvips binaries [kleisauke]
-
-## Version 2.2.3 (released 28 April 2024)
+# master 
 
 - ensure compatibility with a single shared libvips library [kleisauke]
 - add flags_dict(), enum_dict() for better flags introspection

--- a/pyvips/__init__.py
+++ b/pyvips/__init__.py
@@ -15,11 +15,11 @@ def library_name(name, abi_number):
     is_mac = sys.platform == 'darwin'
 
     if is_windows:
-        return 'lib{0}-{1}.dll'.format(name, abi_number)
+        return f'lib{name}-{abi_number}.dll'
     elif is_mac:
-        return 'lib{0}.{1}.dylib'.format(name, abi_number)
+        return f'lib{name}.{abi_number}.dylib'
     else:
-        return 'lib{0}.so.{1}'.format(name, abi_number)
+        return f'lib{name}.so.{abi_number}'
 
 # pull in our module version number
 from .version import __version__


### PR DESCRIPTION
Context:
> pyvips could maybe use something similar, I think at the moment it'll try to load glib as a test for semistatic, but that could break on windows if the user has glib from another project on their PATH. Seeing if we can get `g_free` or whatever from libvips ought to be safer.
> _Originally posted by @jcupitt in https://github.com/libvips/ruby-vips/issues/390#issuecomment-1977107148_