### PR TITLE
Add a declaration for `vips_shutdown()`

### DIFF
--- a/pyvips/vdecls.py
+++ b/pyvips/vdecls.py
@@ -75,6 +75,8 @@ def cdefs(features):
         typedef void* (*VipsTypeMap2Fn) (GType type, void* a, void* b);
         void* vips_type_map (GType base, void* fn, void* a, void* b);
 
+        void vips_shutdown (void);
+
         const char* vips_error_buffer (void);
         void vips_error_clear (void);
         void vips_error_freeze (void);


### PR DESCRIPTION
Handy for the leak checker - simply set `VIPS_LEAK=1`, run your program, and call:
```python
pyvips.vips_lib.vips_shutdown()
```
at the end.

An alternative might be to mark `vips_shutdown()` as destructor, see e.g. commit  https://github.com/kleisauke/libvips/commit/f75675fc4e9de0502a12b2a9aa10f643a2b1146b. However, I'm not sure if that  would cause any side effects (just like with `atexit()` in the past).