### PR TITLE
Simplify install notes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,7 +119,7 @@ With Homebrew:
 .. code-block:: shell
 
     $ brew install vips python pkg-config
-    $ pip3 install pyvips
+    $ pip install pyvips
 
 Windows
 ^^^^^^^
@@ -194,8 +194,7 @@ Local user install:
 
 .. code-block:: shell
 
-    $ pip install pyvips-binary==8.16.0
-    $ pip3 install -e .
+    $ pip install -e .[binary]
     $ pypy -m pip --user -e .
 
 Run all tests:


### PR DESCRIPTION
Noticed this after I wrote comment https://github.com/libvips/pyvips/pull/507#issuecomment-2724645016. However, this is not an issue for [editable installs](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs). For example, this is all fine:
```console
$ pip uninstall -y pyvips pyvips-binary
$ pip cache purge
$ pip install -e .[binary]
$ ldd $(python -m site --user-site)/_libvips.abi3.so | grep libvips
	libvips-65e2e1b0.so.42 => /home/kleisauke/.local/lib/python3.13/site-packages/pyvips_binary.libs/libvips-65e2e1b0.so.42 (0x00007f1d86c00000)
```
```console
$ pip uninstall -y pyvips pyvips-binary
$ pip cache purge
$ pip install pyvips-binary
$ pip install -e .
$ ldd $(python -m site --user-site)/_libvips.abi3.so | grep libvips
	libvips-65e2e1b0.so.42 => /home/kleisauke/.local/lib/python3.13/site-packages/pyvips_binary.libs/libvips-65e2e1b0.so.42 (0x00007f1d86c00000)
```

But this builds against a globally installed libvips, if present.
```console
$ pip uninstall -y pyvips pyvips-binary
$ pip cache purge
$ pip install .[binary]
$ ldd $(python -m site --user-site)/_libvips.abi3.so | grep libvips
	libvips.so.42 => /lib64/libvips.so.42 (0x00007fa0f3c00000)
```
```console
$ pip uninstall -y pyvips pyvips-binary
$ pip cache purge
$ pip install pyvips-binary
$ pip install .
$ ldd $(python -m site --user-site)/_libvips.abi3.so | grep libvips
	libvips.so.42 => /lib64/libvips.so.42 (0x00007f5d8a200000)
```