### PR TITLE
Remove redundant build dependency on wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     # First version of setuptools to support pyproject.toml configuration
     "setuptools>=61.0.0",
-    "wheel",
     # Must be kept in sync with `project.dependencies`
     "cffi>=1.0.0",
     "pkgconfig>=1.5",


### PR DESCRIPTION
It was likely added in preparation for the pre-built binary wheels, now provided by pyvips-binary. Discovered while reviewing https://github.com/kleisauke/pyvips-binary/commit/7d39fb0e8c8e97f727bcffa7832b24598f8d0af0.