### PR TITLE
CI: run `apt-get update` before installing libvips

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install libvips
-        run: sudo apt-get install --no-install-recommends libvips
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends libvips
 
       - name: Lint with flake8
         run: |


### PR DESCRIPTION
See:
https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners

and the failures in PR #537.