### PR TITLE
Call vips_shutdown on exit to prevent segfault

### DIFF
--- a/pyvips/__init__.py
+++ b/pyvips/__init__.py
@@ -186,6 +186,12 @@ def _remove_log_handler():
 
 atexit.register(_remove_log_handler)
 
+# shut down libvips on exit to drain the thread pool, preventing
+# segfaults from worker threads accessing unmapped memory during
+# Python's final GC pass
+_shutdown = vips_lib.vips_shutdown
+atexit.register(_shutdown)
+
 from .enums import *
 from .base import *
 from .gobject import *


### PR DESCRIPTION
Register `vips_shutdown` as an atexit handler to drain the libvips thread pool before Python tears down. Without this, worker threads waiting on a condition variable can try to execute code from unmapped memory during Python's final GC pass, causing an intermittent segfault on exit.

The function pointer is cached before registering (same pattern as `_remove_log_handler`) since ffi lookups can fail during shutdown. Calling `vips_shutdown` multiple times is safe per the libvips docs, so it doesn't matter if `pyvips.shutdown()` was already called manually.