### PR TITLE
Specify packages using include rather than exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,8 @@ include-package-data = false
 version = {attr = "pyvips.version.__version__"}
 
 [tool.setuptools.packages.find]
-exclude = [
-    "doc*",
-    "examples*",
-    "tests*",
+include = [
+    "pyvips",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This avoids possible duplication if a wheel is built more than once from the same directory.