### PR TITLE
Use explicit Python 3 shebang in examples

### DIFF
--- a/examples/affine.py
+++ b/examples/affine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/annotate-animation.py
+++ b/examples/annotate-animation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/cod.py
+++ b/examples/cod.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/connection.py
+++ b/examples/connection.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/convolve.py
+++ b/examples/convolve.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """ example pyvips code to convolve an image with a 3x3 mask
 

--- a/examples/join-animation.py
+++ b/examples/join-animation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/orientation.py
+++ b/examples/orientation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/pil-numpy-pyvips.py
+++ b/examples/pil-numpy-pyvips.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import time

--- a/examples/progress.py
+++ b/examples/progress.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import pyvips
 

--- a/examples/read_profile.py
+++ b/examples/read_profile.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/shepard.py
+++ b/examples/shepard.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Shepard's distortion, from https://github.com/tourtiere/light-distortion
 # with kind permission.

--- a/examples/soak-test.py
+++ b/examples/soak-test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/split-animation.py
+++ b/examples/split-animation.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/stdio.py
+++ b/examples/stdio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/stream.py
+++ b/examples/stream.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import requests

--- a/examples/thumb-dir.py
+++ b/examples/thumb-dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 example pyvips code to run thumbnail on a dir full of images

--- a/examples/try1.py
+++ b/examples/try1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/try10.py
+++ b/examples/try10.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # import logging
 # logging.basicConfig(level = logging.DEBUG)

--- a/examples/try11.py
+++ b/examples/try11.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try12.py
+++ b/examples/try12.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/try13.py
+++ b/examples/try13.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # import pyvips
 import logging

--- a/examples/try14.py
+++ b/examples/try14.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # import logging
 # logging.basicConfig(level = logging.DEBUG)

--- a/examples/try16.py
+++ b/examples/try16.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import sys

--- a/examples/try17.py
+++ b/examples/try17.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 

--- a/examples/try2.py
+++ b/examples/try2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import pyvips

--- a/examples/try3.py
+++ b/examples/try3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try4.py
+++ b/examples/try4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try5.py
+++ b/examples/try5.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try6.py
+++ b/examples/try6.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try7.py
+++ b/examples/try7.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/try8.py
+++ b/examples/try8.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # import logging
 # logging.basicConfig(level = logging.DEBUG)

--- a/examples/try9.py
+++ b/examples/try9.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import pyvips

--- a/examples/watermark.py
+++ b/examples/watermark.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips

--- a/examples/watermark_context.py
+++ b/examples/watermark_context.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # watermark an image, but do it in a context-sensitive way, so we will write
 # black if the area we are overlaying the text on is white, for example

--- a/examples/watermark_image.py
+++ b/examples/watermark_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import pyvips


### PR DESCRIPTION
Avoid ambiguity on systems where `python` is unavailable (e.g. on Ubuntu you'll need to install `python-is-python3` or create a symlink manually).